### PR TITLE
Use environment vars for secrets

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -20,10 +21,13 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # See https://docs.djangoproject.com/en/5.2/howto/deployment/checklist/
 
 # SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = 'django-insecure-ua_&hud*34c8-4tq7+_xd*c40drb1s%@yr$2n6p=4@k^@2$npe'
+SECRET_KEY = os.environ.get(
+    'DJANGO_SECRET_KEY',
+    'django-insecure-ua_&hud*34c8-4tq7+_xd*c40drb1s%@yr$2n6p=4@k^@2$npe',
+)
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.environ.get('DJANGO_DEBUG', 'True') == 'True'
 
 ALLOWED_HOSTS = []
 
@@ -78,11 +82,11 @@ WSGI_APPLICATION = 'config.wsgi.application'
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'castera_db_main',
-        'USER': 'castera_user_main',
-        'PASSWORD': 'castera_pass_main',
-        'HOST': 'db',  
-        'PORT': '5432',  
+        'NAME': os.environ.get('POSTGRES_DB', 'castera_db_main'),
+        'USER': os.environ.get('POSTGRES_USER', 'castera_user_main'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'castera_pass_main'),
+        'HOST': os.environ.get('POSTGRES_HOST', 'db'),
+        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
     }
 }
 
@@ -134,7 +138,10 @@ CHANNEL_LAYERS = {
     'default': {
         'BACKEND': 'channels_redis.core.RedisChannelLayer',
         'CONFIG': {
-            "hosts": [("redis", 6378)],
+            "hosts": [(
+                os.environ.get('REDIS_HOST', 'redis'),
+                int(os.environ.get('REDIS_PORT', '6378')),
+            )],
         },
     },
 }

--- a/config/test_settings.py
+++ b/config/test_settings.py
@@ -1,16 +1,17 @@
 from .settings import *
+import os
 
 # Use PostgreSQL database from Docker for tests
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql',
-        'NAME': 'castera_db_main',
-        'USER': 'castera_user_main',
-        'PASSWORD': 'castera_pass_main',
-        'HOST': 'db',
-        'PORT': '5432',
+        'NAME': os.environ.get('POSTGRES_DB', 'castera_db_main'),
+        'USER': os.environ.get('POSTGRES_USER', 'castera_user_main'),
+        'PASSWORD': os.environ.get('POSTGRES_PASSWORD', 'castera_pass_main'),
+        'HOST': os.environ.get('POSTGRES_HOST', 'db'),
+        'PORT': os.environ.get('POSTGRES_PORT', '5432'),
         'TEST': {
-            'NAME': 'castera_test',
+            'NAME': os.environ.get('POSTGRES_TEST_DB', 'castera_test'),
         },
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,17 +8,27 @@ services:
     volumes:
       - .:/app
     ports:
-      - "8100:8000"  
+      - "8100:8000"
     depends_on:
       - db
       - redis  #  مهم إذا بدك Channels تشتغل
+    environment:
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DJANGO_DEBUG: ${DJANGO_DEBUG:-True}
+      POSTGRES_DB: ${POSTGRES_DB:-castera_db_main}
+      POSTGRES_USER: ${POSTGRES_USER:-castera_user_main}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-castera_pass_main}
+      POSTGRES_HOST: ${POSTGRES_HOST:-db}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      REDIS_HOST: ${REDIS_HOST:-redis}
+      REDIS_PORT: ${REDIS_PORT:-6378}
 
   db:
     image: postgres:15
     environment:
-      POSTGRES_DB: castera_db_main
-      POSTGRES_USER: castera_user_main
-      POSTGRES_PASSWORD: castera_pass_main
+      POSTGRES_DB: ${POSTGRES_DB:-castera_db_main}
+      POSTGRES_USER: ${POSTGRES_USER:-castera_user_main}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-castera_pass_main}
     ports:
       - "55432:5432"  
     volumes:

--- a/dockerfile
+++ b/dockerfile
@@ -3,6 +3,15 @@ FROM python:3.11.8-slim-bookworm
 
 ENV PYTHONDONTWRITEBYTECODE 1
 ENV PYTHONUNBUFFERED 1
+ENV DJANGO_SECRET_KEY=dummy_secret_key \
+    DJANGO_DEBUG=False \
+    POSTGRES_DB=castera_db_main \
+    POSTGRES_USER=castera_user_main \
+    POSTGRES_PASSWORD=castera_pass_main \
+    POSTGRES_HOST=db \
+    POSTGRES_PORT=5432 \
+    REDIS_HOST=redis \
+    REDIS_PORT=6378
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- load SECRET_KEY and DEBUG from env vars
- read database and Redis settings from env vars in settings
- update test settings to use env vars
- pass secrets via docker-compose
- add default env vars in Dockerfile

## Testing
- `pip install -r requirements.txt`
- `python manage.py test --settings=config.test_settings` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_684943193bf08329bf1170be20a540fd