### PR TITLE
Fix superuser password creation

### DIFF
--- a/users/models.py
+++ b/users/models.py
@@ -2,19 +2,29 @@ from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseU
 from django.db import models
 
 class CustomUserManager(BaseUserManager):
-    def create_user(self, email, **extra_fields):
+    def create_user(self, email, password=None, **extra_fields):
+        """Create and return a regular user."""
         if not email:
-            raise ValueError('The Email must be set')
+            raise ValueError("The Email must be set")
         email = self.normalize_email(email)
         user = self.model(email=email, **extra_fields)
-        user.set_unusable_password()  # Clerk handles auth
+        if password:
+            user.set_password(password)
+        else:
+            # Clerk handles authentication for accounts without a password
+            user.set_unusable_password()
         user.save()
         return user
 
-    def create_superuser(self, email, **extra_fields):
-        extra_fields.setdefault('is_staff', True)
-        extra_fields.setdefault('is_superuser', True)
-        return self.create_user(email, **extra_fields)
+    def create_superuser(self, email, password=None, **extra_fields):
+        """Create and return a superuser with a usable password."""
+        extra_fields.setdefault("is_staff", True)
+        extra_fields.setdefault("is_superuser", True)
+
+        if password is None:
+            raise TypeError("Superusers must have a password.")
+
+        return self.create_user(email, password=password, **extra_fields)
 
 class User(AbstractBaseUser, PermissionsMixin):
     email = models.EmailField(unique=True)

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,23 @@
 from django.test import TestCase
+from django.contrib.auth import get_user_model
 
-# Create your tests here.
+
+class UserManagerTests(TestCase):
+    def test_create_user_without_password(self):
+        User = get_user_model()
+        user = User.objects.create_user(email="user@example.com")
+        self.assertFalse(user.has_usable_password())
+
+    def test_create_superuser_with_password(self):
+        User = get_user_model()
+        admin = User.objects.create_superuser(
+            email="admin@example.com", password="adminpass"
+        )
+        self.assertTrue(admin.is_staff)
+        self.assertTrue(admin.is_superuser)
+        self.assertTrue(admin.check_password("adminpass"))
+
+    def test_create_superuser_without_password_raises(self):
+        User = get_user_model()
+        with self.assertRaises(TypeError):
+            User.objects.create_superuser(email="nopass@example.com")


### PR DESCRIPTION
## Summary
- allow specifying passwords in `CustomUserManager`
- add tests ensuring superuser creation stores password and enforces it

## Testing
- `python manage.py test --settings=config.test_settings` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_684947e71b3883298d8f34841fd533b4