### PR TITLE
Add admin interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ docker compose up --build
 
 The web service listens on port `8100` by default. A PostgreSQL database and a Redis instance are started automatically.
 
+To access the Django admin you will need a superuser account:
+
+```bash
+docker compose run web python manage.py createsuperuser
+```
+
+Once created, visit `http://localhost:8100/admin/` and log in with the credentials.
+
 Apply database migrations with:
 
 ```bash

--- a/meetings/admin.py
+++ b/meetings/admin.py
@@ -1,3 +1,29 @@
 from django.contrib import admin
+from .models import Meeting, Message, Signal, Recording
 
-# Register your models here.
+
+@admin.register(Meeting)
+class MeetingAdmin(admin.ModelAdmin):
+    list_display = ("title", "user", "type_of", "scheduled_date", "status")
+    search_fields = ("title", "user__email", "room_id")
+    list_filter = ("status", "type_of")
+    readonly_fields = ("room_id", "created_on")
+
+
+@admin.register(Message)
+class MessageAdmin(admin.ModelAdmin):
+    list_display = ("meeting", "user", "timestamp")
+    search_fields = ("meeting__title", "user__email", "content")
+
+
+@admin.register(Signal)
+class SignalAdmin(admin.ModelAdmin):
+    list_display = ("meeting", "sender", "signal_type", "created_at")
+    search_fields = ("meeting__title", "sender__email")
+    list_filter = ("signal_type",)
+
+
+@admin.register(Recording)
+class RecordingAdmin(admin.ModelAdmin):
+    list_display = ("meeting", "uploaded_by", "created_at")
+    search_fields = ("meeting__title", "uploaded_by__email")


### PR DESCRIPTION
## Summary
- expose Meeting models in Django admin
- document how to create a superuser and access admin

## Testing
- `python manage.py test --settings=config.test_settings` *(fails: could not translate host name "db" to address)*

------
https://chatgpt.com/codex/tasks/task_e_68494a0f94888329a8fcbbda0d2d8e71