### PR TITLE
Add auth and permission tests

### DIFF
--- a/users/tests.py
+++ b/users/tests.py
@@ -1,5 +1,7 @@
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APITestCase, APIClient
 
 
 class UserManagerTests(TestCase):
@@ -21,3 +23,34 @@ class UserManagerTests(TestCase):
         User = get_user_model()
         with self.assertRaises(TypeError):
             User.objects.create_superuser(email="nopass@example.com")
+
+
+class AuthEndpointTests(APITestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.register_url = reverse("user-register")
+        self.login_url = reverse("user-login")
+
+    def test_register_user(self):
+        data = {"email": "new@example.com", "password": "strongpass"}
+        resp = self.client.post(self.register_url, data, format="json")
+        self.assertEqual(resp.status_code, 201)
+
+    def test_register_invalid_data(self):
+        data = {"email": "bad@example.com"}  # missing password
+        resp = self.client.post(self.register_url, data, format="json")
+        self.assertEqual(resp.status_code, 400)
+
+    def test_login_valid_credentials(self):
+        User = get_user_model()
+        User.objects.create_user(email="user2@example.com", password="pass1234")
+        data = {"email": "user2@example.com", "password": "pass1234"}
+        resp = self.client.post(self.login_url, data, format="json")
+        self.assertEqual(resp.status_code, 200)
+
+    def test_login_invalid_credentials(self):
+        User = get_user_model()
+        User.objects.create_user(email="user3@example.com", password="pass1234")
+        data = {"email": "user3@example.com", "password": "wrong"}
+        resp = self.client.post(self.login_url, data, format="json")
+        self.assertEqual(resp.status_code, 400)


### PR DESCRIPTION
## Summary
- extend meeting tests with permission and invalid-input cases
- add registration/login API tests

## Testing
- `python manage.py test --settings=config.test_settings` *(fails: could not translate host name "db" to address: Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68494b3488d48329861e89478c1cb30d